### PR TITLE
Revert "update storage config"

### DIFF
--- a/rootdir/fstab.qcom
+++ b/rootdir/fstab.qcom
@@ -9,6 +9,6 @@
 /dev/block/platform/msm_sdcc.1/by-name/cache       /cache     ext4  noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic  wait,check
 /dev/block/platform/msm_sdcc.1/by-name/userdata    /data      ext4  noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic  wait,check,encryptable=footer,length=-16384
 
-/devices/msm_sdcc.2/mmc_host*                      auto       auto  defaults  voldmanaged=sdcard1:auto,noemulatedsd
-/devices/msm_sdcc.3/mmc_host*                      auto       auto  defaults  voldmanaged=sdcard1:auto,noemulatedsd
-/devices/platform/xhci-hcd                         auto       auto  defaults  voldmanaged=usbdisk:auto
+/devices/msm_sdcc.2/mmc_host*                     auto              auto  defaults  voldmanaged=sdcard1:auto
+/devices/msm_sdcc.3/mmc_host*                     auto              auto  defaults  voldmanaged=sdcard1:auto
+/devices/platform/xhci-hcd                       auto              auto  defaults  voldmanaged=usbdisk:auto

--- a/rootdir/init.qcom.rc
+++ b/rootdir/init.qcom.rc
@@ -518,17 +518,17 @@ service iprenew_bt-pan /system/bin/dhcpcd -n
 
 on property:ro.data.large_tcp_window_size=true
     # Adjust socket buffer to enlarge TCP receive window for high bandwidth (e.g. DO-RevB)
-    write /proc/sys/net/ipv4/tcp_adv_win_scale 2
+    write /proc/sys/net/ipv4/tcp_adv_win_scale  2
 
 # virtual sdcard daemon running as media_rw (1023)
 service sdcard /system/bin/sdcard -u 1023 -g 1023 -l /data/media /mnt/shell/emulated
     class late_start
 
-service fuse_sdcard1 /system/bin/sdcard -u 1023 -g 1023 -w 1023 -d /mnt/media_rw/sdcard1 /storage/sdcard1
+service fuse_sdcard1 /system/bin/sdcard -u 1023 -g 1023 -d /mnt/media_rw/sdcard1 /storage/sdcard1
     class late_start
     disabled
 
-service fuse_usbdisk /system/bin/sdcard -u 1023 -g 1023 -w 1023 -d /mnt/media_rw/usbdisk /storage/usbdisk
+service fuse_usbdisk /system/bin/sdcard -u 1023 -g 1023 -d /mnt/media_rw/usbdisk /storage/usbdisk
     class late_start
     disabled
 


### PR DESCRIPTION
This reverts commit e46dfd30578e1f338fb1f0611bc1f4b9bb0cb1c0.

I found that some apps (Bittorrent Sync / Xplore file manager) suddenly had read-only access again to the sdcard.

If this is the intended behavior, please ignore this :-) I had to use https://play.google.com/store/apps/details?id=nextapp.sdfix to get the old behavior like I had to on the kitkat days.

I don't have this issue on my Nexus 7.
